### PR TITLE
AGID-484 Caricare upstream le modifiche di searchyll (#159991970) - Rimuove definizione dei path dei file (mapping e fields) hardcoded. Definizione delegata all'istanza jekyll.

### DIFF
--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -31,11 +31,11 @@ begin
     # strip html
     nokogiri_doc = Nokogiri::HTML(page.output)
 
-    # puts %(        indexing page #{page.url})
+    puts %(        indexing page #{page.url})
 
     if (indexer = indexers[page.site])
       indexer << page.data.merge({
-        id:     page.name,
+        id:     defined? page.title ? page.title : page.name,
         url:    page.url,
         text:   nokogiri_doc.xpath("//article//text()").to_s.gsub(/\s+/, " ")
       })

--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -31,7 +31,7 @@ begin
     # strip html
     nokogiri_doc = Nokogiri::HTML(page.output)
 
-    puts %(        indexing page #{page.url})
+    # puts %(        indexing page #{page.url})
 
     if (indexer = indexers[page.site])
       indexer << page.data.merge({

--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -35,5 +35,14 @@ module Searchyll
     def elasticsearch_default_type
       site.config['elasticsearch']['default_type'] || 'post'
     end
+
+    # Getter for the mapping fields file's path value
+    def elasticsearch_analysis_fields
+      site.config['elasticsearch']['analysis_file_path'] || './mapping/analysis.json'
+    end
+    # Getter for the analysis fields file's path value
+    def elasticsearch_mapping_fields
+      site.config['elasticsearch']['mapping_file_path'] || './mapping/mapping.json'
+    end
   end
 end

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -1,12 +1,9 @@
 require 'json'
 require 'net/http'
+require 'yaml'
 
 module Searchyll
   class Indexer
-    # Mapping fields JSON file path
-    MAPPING_FILE_PATH = './mapping/fields.json'
-    # Analysis fields JSON file path
-    ANALYSIS_FILE_PATH = './mapping/analysis.json'
     # Initial size of document batches to send to ES _bulk API
     BATCH_SIZE = 50
 
@@ -34,6 +31,10 @@ module Searchyll
       self.working       = true
       self.timestamp     = Time.now
       self.batch_size    = BATCH_SIZE
+      # Mapping fields JSON file path
+      @@mapping_file_path = configuration.elasticsearch_mapping_fields
+      # Analysis fields JSON file path
+      @@analysis_file_path = configuration.elasticsearch_analysis_fields
     end
 
     # Public: Add new documents for batch indexing.
@@ -115,13 +116,13 @@ module Searchyll
 
     # Prepare our indexing run by creating a new index.
     def prepare_index
-      if File.exist?(MAPPING_FILE_PATHS)
-        mapping_fields = JSON.parse(File.read(MAPPING_FILE_PATHS))
+      if File.exist?(@@mapping_file_path)
+        mapping_fields = JSON.parse(File.read(@@mapping_file_path))
       else
         mapping_fields = false
       end
-      if File.exist?(ANALYSIS_FILE_PATH)
-        analysis_fields = JSON.parse(File.read(ANALYSIS_FILE_PATH))
+      if File.exist?(@@analysis_file_path)
+        analysis_fields = JSON.parse(File.read(@@analysis_file_path))
       else
         analysis_fields = false
       end
@@ -136,11 +137,13 @@ module Searchyll
       
       # Add mapping fields to the index
       if mapping_fields
+        create_index.class.instance_eval('attr_accessor :mappings')
         create_index.mappings = mapping_fields
       end
 
       # Add analysis fields to the index
       if analysis_fields
+        create_index.class.instance_eval('attr_accessor :analysis')
         create_index.analysis = analysis_fields
       end
 


### PR DESCRIPTION
La modifica delega all'istanza jekyll che usa il plugin l'esistenza dei valori delle variabili **mapping_file_path** e **analysis_file_path**. Questi dovranno quindi essere specificati, nel file _**_config.yml**_ dell'istanza jekyll, come da esempio seguente:
```
elasticsearch:
  url: ENV_ELASTICSEARCH_URL
  ...
  # Mapping fields JSON file path
  mapping_file_path: '/usr/opt/searchyll/lib/searchyll/mapping/fields.json'
  # Analysis fields JSON file path
  analysis_file_path: '/usr/opt/searchyll/lib/searchyll/mapping/analysis.json'
```
Nell'esempio stiamo indicando a searchyll la posizione in cui andare a cercare i due file. Solo se esistenti verranno interpretati ed aggiungi all'indicizzazione.


La PR implementa inoltre una piccola modifica che ovvia alla possibile eventualità di errore nella lettura della proprietà **page.title** (a volte non definita); solo in tal caso si ripiegherà su **page.name**.
